### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,58 @@ No dependencies. Only pure Javascript.
 use ```Schema``` to create type definition.
 
 ```typescript
-/*
-{
-  id: string;
-  name: string;
-  email?: string;
-  createdAt: number;
-}
-*/
 const user = Schema.Object({
   id: Schema.String(),
   name: Schema.String(),
   email: Schema.Optional(Schema.String()),
+  gender: Schema.Nullable(Schema.Enum(["women", "men"])),
   createdAt: Schema.Number(),
 });
+
+const union = Schema.Union([
+  Schema.Number(),
+  Schema.String(),
+  Schema.Union([
+    Schema.Number(),
+    Schema.String(),
+    Schema.Bolean()
+  ]),
+]);
+```
+
+and it supports static type resolution. import ```Resolve```.
+
+```typescript
+const user = Schema.Object({
+  id: Schema.String(),
+  name: Schema.String(),
+  email: Schema.Optional(Schema.String()),
+  gender: Schema.Nullable(Schema.Enum(["women", "men"])),
+  createdAt: Schema.Number(),
+});
+
+/*
+{
+  id: string;
+  name: string;
+  email?: string | undefined;
+  gender: "women" | "men" | null;
+  createdAt: number;
+}
+*/
+type User = Resolve<typeof user>;
 ```
 
 ## Validator
 use ```Validator``` to compare [Schema](#schema) with value.
 
+it returns ```{ success: true }``` if validation succeeded. otherwise, it returns error which includes message.
+
 ```typescript
-Validator.validate(Schema.Number(), 1234); // true
-Validator.validate(Schema.Array(Schema.String()), [1, 2, 3, 4]); // false
+Validator.validate(Schema.Number(), 1234).success; // true
+
+Validator.validate(Schema.Array(Schema.String()), [1, 2, 3, 4]).success; // false
+Validator.validate(Schema.Array(Schema.String()), [1, 2, 3, 4]).error.description; // "should be Array<string>"
 ```
 
 ## HTTP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "request-typer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "request-typer",
-  "version": "1.0.1",
-  "description": "make typed request schema and build OpenAPI Specification",
+  "version": "1.1.0",
+  "description": "Make typed request schema and build OpenAPI Specification",
   "files": [
     "dst"
   ],

--- a/src/OASBuilder.ts
+++ b/src/OASBuilder.ts
@@ -39,7 +39,7 @@ export class OASBuilder {
   private createComponents(): OpenAPIV3.ComponentsObject {
     const schemas: NonNullable<OpenAPIV3.ComponentsObject["schemas"]> = {};
     this.responseSchemaKeyValuePairs.forEach(([key, value]) => {
-      schemas[key] = this.createSchema({ type: "object", properties: value, options: {} });
+      schemas[key] = this.createSchema({ type: "object", properties: value, options: {}, definition: "" });
     });
     return { schemas };
   }
@@ -78,6 +78,7 @@ export class OASBuilder {
                     return result;
                   })(),
                   options: {},
+                  definition: "",
                 }),
               },
             },
@@ -103,6 +104,7 @@ export class OASBuilder {
                       type: "object",
                       properties: requestSchema.response,
                       options: {},
+                      definition: "",
                     });
               })(),
             },

--- a/src/OASBuilder.ts
+++ b/src/OASBuilder.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3 } from "openapi-types";
 
-import { AllType } from "./schema";
+import { AllSchema } from "./schema";
 import { HTTPRequest, Method, Parameters, ResponseBody } from "./http";
 
 export class OASBuilder {
@@ -114,7 +114,7 @@ export class OASBuilder {
     };
   }
 
-  private createSchema(schema: AllType): OpenAPIV3.SchemaObject {
+  private createSchema(schema: AllSchema): OpenAPIV3.SchemaObject {
     const nullable = schema.options.nullable;
     switch (schema.type) {
       case "number": {
@@ -127,7 +127,7 @@ export class OASBuilder {
         return { type: "boolean", ...(nullable ? { nullable } : {}) };
       }
       case "array": {
-        return { type: "array", items: this.createSchema(schema.itemType), ...(nullable ? { nullable } : {}) };
+        return { type: "array", items: this.createSchema(schema.itemSchema), ...(nullable ? { nullable } : {}) };
       }
       case "object": {
         const properties: NonNullable<OpenAPIV3.SchemaObject["properties"]> = {};
@@ -145,7 +145,7 @@ export class OASBuilder {
         };
       }
       case "union": {
-        return { anyOf: schema.itemTypes.map(this.createSchema), ...(nullable ? { nullable } : {}) };
+        return { anyOf: schema.itemSchemas.map(this.createSchema), ...(nullable ? { nullable } : {}) };
       }
       case "enum": {
         return { type: "string", enum: schema.values, ...(nullable ? { nullable } : {}) };

--- a/src/__test__/schema.test.ts
+++ b/src/__test__/schema.test.ts
@@ -135,21 +135,15 @@ describe("Schema", () => {
       const schema = Schema.Union([
         Schema.Number(),
         Schema.String(),
-        Schema.Boolean(),
-        Schema.Array(Schema.Number()),
-        Schema.Object({}),
-        Schema.Union([Schema.Number(), Schema.String()]),
+        Schema.Union([Schema.Number(), Schema.String(), Schema.Boolean()]),
+        Schema.Object({a: Schema.String()}),
+        Schema.Object({a: Schema.Number()}),
+        Schema.Object({a: Schema.Number()}),
+        Schema.Object({a: Schema.Boolean()})
       ]);
       expect(schema.type).to.be.eq("union");
-      expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq([
-        "number",
-        "string",
-        "boolean",
-        "array",
-        "object",
-        "union",
-      ]);
-      expect(schema.definition).to.be.eq("number | string | boolean | Array<number> | {} | number | string")
+      expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq(["number", "string", "boolean", "object", "object", "object"]);
+      expect(schema.definition).to.be.eq(`number | string | boolean | {\n  a: string\n} | {\n  a: number\n} | {\n  a: boolean\n}`);
     });
   });
 });

--- a/src/__test__/schema.test.ts
+++ b/src/__test__/schema.test.ts
@@ -4,28 +4,28 @@ import { Schema } from "../schema";
 
 describe("Schema", () => {
   describe("Schema.Number", () => {
-    it("should return NumberType object", () => {
+    it("should return NumberSchema object", () => {
       const schema = Schema.Number();
       expect(schema.type).to.be.eq("number");
     });
   });
 
   describe("Schema.String", () => {
-    it("should return StringType object", () => {
+    it("should return StringSchema object", () => {
       const schema = Schema.String();
       expect(schema.type).to.be.eq("string");
     });
   });
 
   describe("Schema.Boolean", () => {
-    it("should return BooleanType object", () => {
+    it("should return BooleanSchema object", () => {
       const schema = Schema.Boolean();
       expect(schema.type).to.be.eq("boolean");
     });
   });
 
   describe("Schema.Enum", () => {
-    it("should return EnumType object", () => {
+    it("should return EnumSchema object", () => {
       const schema = Schema.Enum(["a", "b", "c"]);
       expect(schema.type).to.be.eq("enum");
       expect(schema.values).to.be.deep.eq(["a", "b", "c"]);
@@ -34,54 +34,54 @@ describe("Schema", () => {
   });
 
   describe("Schema.Array", () => {
-    context("when NumberType is passed", () => {
-      it("should return ArrayType<NumberType> object", () => {
+    context("when NumberSchema is passed", () => {
+      it("should return ArraySchema<NumberSchema> object", () => {
         const schema = Schema.Array(Schema.Number());
         expect(schema.type).to.be.eq("array");
-        expect(schema.itemType.type).to.be.eq("number");
+        expect(schema.itemSchema.type).to.be.eq("number");
         expect(schema.definition).to.be.eq("Array<number>");
       });
     });
 
-    context("when StringType is passed", () => {
-      it("should return ArrayType<StringType> object", () => {
+    context("when StringSchema is passed", () => {
+      it("should return ArraySchema<StringSchema> object", () => {
         const schema = Schema.Array(Schema.String());
         expect(schema.type).to.be.eq("array");
-        expect(schema.itemType.type).to.be.eq("string");
+        expect(schema.itemSchema.type).to.be.eq("string");
         expect(schema.definition).to.be.eq("Array<string>");
       });
     });
 
-    context("when BooleanType is passed", () => {
-      it("should return ArrayType<BooleanType> object", () => {
+    context("when BooleanSchema is passed", () => {
+      it("should return ArraySchema<BooleanSchema> object", () => {
         const schema = Schema.Array(Schema.Boolean());
         expect(schema.type).to.be.eq("array");
-        expect(schema.itemType.type).to.be.eq("boolean");
+        expect(schema.itemSchema.type).to.be.eq("boolean");
         expect(schema.definition).to.be.eq("Array<boolean>");
       });
     });
 
-    context("when ObjectType is passed", () => {
-      it("should return ArrayType<ObjectType> object", () => {
+    context("when ObjectSchema is passed", () => {
+      it("should return ArraySchema<ObjectSchema> object", () => {
         const schema = Schema.Array(Schema.Object({}));
         expect(schema.type).to.be.eq("array");
-        expect(schema.itemType.type).to.be.eq("object");
+        expect(schema.itemSchema.type).to.be.eq("object");
         expect(schema.definition).to.be.eq(`Array<{}>`);
       });
     });
 
-    context("when UnionType is passed", () => {
-      it("should return ArrayType<UnionType> object", () => {
+    context("when UnionSchema is passed", () => {
+      it("should return ArraySchema<UnionSchema> object", () => {
         const schema = Schema.Array(Schema.Union([Schema.Number(), Schema.String()]));
         expect(schema.type).to.be.eq("array");
-        expect(schema.itemType.type).to.be.eq("union");
+        expect(schema.itemSchema.type).to.be.eq("union");
         expect(schema.definition).to.be.eq(`Array<number | string>`);
       });
     });
   });
 
   describe("Schema.Object", () => {
-    it("should return ObjectType object", () => {
+    it("should return ObjectSchema object", () => {
       const schema = Schema.Object({
         number: Schema.Number(),
         string: Schema.String(),
@@ -119,7 +119,7 @@ describe("Schema", () => {
   });
 
   describe("Schema.Optional", () => {
-    it("should set Type.optional option to true", () => {
+    it("should set Schema.optional option to true", () => {
       const schema = Schema.Optional(Schema.Number());
       expect(schema.type).to.be.eq("number");
       expect(schema.options.optional).to.be.true;
@@ -127,7 +127,7 @@ describe("Schema", () => {
   });
 
   describe("Schema.Nullable", () => {
-    it("should set Type.nullable option to true", () => {
+    it("should set Schema.nullable option to true", () => {
       const schema = Schema.Nullable(Schema.Number());
       expect(schema.type).to.be.eq("number");
       expect(schema.options.nullable).to.be.true;
@@ -135,7 +135,7 @@ describe("Schema", () => {
   });
 
   describe("Schema.Union", () => {
-    it("should return UnionType object", () => {
+    it("should return UnionSchema object", () => {
       const schema = Schema.Union([
         Schema.Number(),
         Schema.String(),
@@ -146,7 +146,7 @@ describe("Schema", () => {
         Schema.Object({ a: Schema.Boolean() }),
       ]);
       expect(schema.type).to.be.eq("union");
-      expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq([
+      expect(schema.itemSchemas.map(({ type }) => type)).to.be.deep.eq([
         "number",
         "string",
         "boolean",

--- a/src/__test__/schema.test.ts
+++ b/src/__test__/schema.test.ts
@@ -88,7 +88,11 @@ describe("Schema", () => {
         boolean: Schema.Boolean(),
         array: Schema.Array(Schema.Number()),
         object: Schema.Object({}),
-        union: Schema.Union([Schema.Number(), Schema.String()]),
+        union: Schema.Union([
+          Schema.Number(),
+          Schema.String(),
+          Schema.Union([Schema.Number(), Schema.String(), Schema.Boolean()]),
+        ]),
         optional: Schema.Optional(Schema.Number()),
       });
 
@@ -101,15 +105,15 @@ describe("Schema", () => {
       expect(schema.properties.union.type).to.be.eq("union");
       expect(schema.properties.optional.options.optional).to.be.true;
       expect(schema.definition).to.be.eq(
-        `{\n${[
-          "  number: number",
-          "  string: string",
-          "  boolean: boolean",
-          "  array: Array<number>",
-          "  object: {}",
-          "  union: number | string",
-          "  optional?: number",
-        ].join(",\n")}\n}`
+        `{ ${[
+          "number: number",
+          "string: string",
+          "boolean: boolean",
+          "array: Array<number>",
+          "object: {}",
+          "union: number | string | boolean",
+          "optional?: number",
+        ].join(", ")} }`
       );
     });
   });
@@ -136,14 +140,21 @@ describe("Schema", () => {
         Schema.Number(),
         Schema.String(),
         Schema.Union([Schema.Number(), Schema.String(), Schema.Boolean()]),
-        Schema.Object({a: Schema.String()}),
-        Schema.Object({a: Schema.Number()}),
-        Schema.Object({a: Schema.Number()}),
-        Schema.Object({a: Schema.Boolean()})
+        Schema.Object({ a: Schema.String() }),
+        Schema.Object({ a: Schema.Number() }),
+        Schema.Object({ a: Schema.Number() }),
+        Schema.Object({ a: Schema.Boolean() }),
       ]);
       expect(schema.type).to.be.eq("union");
-      expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq(["number", "string", "boolean", "object", "object", "object"]);
-      expect(schema.definition).to.be.eq(`number | string | boolean | {\n  a: string\n} | {\n  a: number\n} | {\n  a: boolean\n}`);
+      expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq([
+        "number",
+        "string",
+        "boolean",
+        "object",
+        "object",
+        "object",
+      ]);
+      expect(schema.definition).to.be.eq(`number | string | boolean | { a: string } | { a: number } | { a: boolean }`);
     });
   });
 });

--- a/src/__test__/schema.test.ts
+++ b/src/__test__/schema.test.ts
@@ -29,6 +29,7 @@ describe("Schema", () => {
       const schema = Schema.Enum(["a", "b", "c"]);
       expect(schema.type).to.be.eq("enum");
       expect(schema.values).to.be.deep.eq(["a", "b", "c"]);
+      expect(schema.definition).to.be.eq(`"a" | "b" | "c"`);
     });
   });
 
@@ -38,6 +39,7 @@ describe("Schema", () => {
         const schema = Schema.Array(Schema.Number());
         expect(schema.type).to.be.eq("array");
         expect(schema.itemType.type).to.be.eq("number");
+        expect(schema.definition).to.be.eq("Array<number>");
       });
     });
 
@@ -46,6 +48,7 @@ describe("Schema", () => {
         const schema = Schema.Array(Schema.String());
         expect(schema.type).to.be.eq("array");
         expect(schema.itemType.type).to.be.eq("string");
+        expect(schema.definition).to.be.eq("Array<string>");
       });
     });
 
@@ -54,6 +57,7 @@ describe("Schema", () => {
         const schema = Schema.Array(Schema.Boolean());
         expect(schema.type).to.be.eq("array");
         expect(schema.itemType.type).to.be.eq("boolean");
+        expect(schema.definition).to.be.eq("Array<boolean>");
       });
     });
 
@@ -62,14 +66,16 @@ describe("Schema", () => {
         const schema = Schema.Array(Schema.Object({}));
         expect(schema.type).to.be.eq("array");
         expect(schema.itemType.type).to.be.eq("object");
+        expect(schema.definition).to.be.eq(`Array<{}>`);
       });
     });
 
     context("when UnionType is passed", () => {
       it("should return ArrayType<UnionType> object", () => {
-        const schema = Schema.Array(Schema.Union([]));
+        const schema = Schema.Array(Schema.Union([Schema.Number(), Schema.String()]));
         expect(schema.type).to.be.eq("array");
         expect(schema.itemType.type).to.be.eq("union");
+        expect(schema.definition).to.be.eq(`Array<number | string>`);
       });
     });
   });
@@ -82,7 +88,7 @@ describe("Schema", () => {
         boolean: Schema.Boolean(),
         array: Schema.Array(Schema.Number()),
         object: Schema.Object({}),
-        union: Schema.Union([]),
+        union: Schema.Union([Schema.Number(), Schema.String()]),
         optional: Schema.Optional(Schema.Number()),
       });
 
@@ -94,6 +100,17 @@ describe("Schema", () => {
       expect(schema.properties.object.type).to.be.eq("object");
       expect(schema.properties.union.type).to.be.eq("union");
       expect(schema.properties.optional.options.optional).to.be.true;
+      expect(schema.definition).to.be.eq(
+        `{\n${[
+          "  number: number",
+          "  string: string",
+          "  boolean: boolean",
+          "  array: Array<number>",
+          "  object: {}",
+          "  union: number | string",
+          "  optional?: number",
+        ].join(",\n")}\n}`
+      );
     });
   });
 
@@ -121,7 +138,7 @@ describe("Schema", () => {
         Schema.Boolean(),
         Schema.Array(Schema.Number()),
         Schema.Object({}),
-        Schema.Union([]),
+        Schema.Union([Schema.Number(), Schema.String()]),
       ]);
       expect(schema.type).to.be.eq("union");
       expect(schema.itemTypes.map(({ type }) => type)).to.be.deep.eq([
@@ -132,6 +149,7 @@ describe("Schema", () => {
         "object",
         "union",
       ]);
+      expect(schema.definition).to.be.eq("number | string | boolean | Array<number> | {} | number | string")
     });
   });
 });

--- a/src/__test__/validator.test.ts
+++ b/src/__test__/validator.test.ts
@@ -8,95 +8,111 @@ describe("Validator", () => {
     context("when NumberType is passed", () => {
       const schema = Schema.Number();
 
-      it("should return true if value is evaluated as number", () => {
-        expect(Validator.validate(schema, 1234)).to.be.true;
+      it("should return success result if value is evaluated as number", () => {
+        expect(Validator.validate(schema, 1234).success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as number", () => {
-        expect(Validator.validate(schema, "1234")).to.be.false;
+      it("should return failed result if value isn't evaluated as number", () => {
+        const result = Validator.validate(schema, "1234");
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be number");
       });
     });
 
     context("when StringType is passed", () => {
       const schema = Schema.String();
 
-      it("should return true if value is evaluated as string", () => {
-        expect(Validator.validate(schema, "1234")).to.be.true;
+      it("should return success result if value is evaluated as string", () => {
+        expect(Validator.validate(schema, "1234").success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as string", () => {
-        expect(Validator.validate(schema, 1234)).to.be.false;
+      it("should return failed result if value isn't evaluated as string", () => {
+        const result = Validator.validate(schema, 1234);
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be string");
       });
     });
 
     context("when BooleanType is passed", () => {
       const schema = Schema.Boolean();
 
-      it("should return true if value is evaluated as boolean", () => {
-        expect(Validator.validate(schema, true)).to.be.true;
-        expect(Validator.validate(schema, false)).to.be.true;
+      it("should return success result if value is evaluated as boolean", () => {
+        expect(Validator.validate(schema, true).success).to.be.true;
+        expect(Validator.validate(schema, false).success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as boolean", () => {
-        expect(Validator.validate(schema, "1234")).to.be.false;
+      it("should return failed result if value isn't evaluated as boolean", () => {
+        const result = Validator.validate(schema, 1);
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be boolean");
       });
     });
 
     context("when EnumType is passed", () => {
       const schema = Schema.Enum(["a", "b", "c"]);
 
-      it("should return true if value is evaluated as enum", () => {
-        expect(Validator.validate(schema, "a")).to.be.true;
-        expect(Validator.validate(schema, "b")).to.be.true;
-        expect(Validator.validate(schema, "c")).to.be.true;
+      it("should return success result if value is evaluated as enum", () => {
+        expect(Validator.validate(schema, "a").success).to.be.true;
+        expect(Validator.validate(schema, "b").success).to.be.true;
+        expect(Validator.validate(schema, "c").success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as enum", () => {
-        expect(Validator.validate(schema, "1234")).to.be.false;
+      it("should return failed result if value isn't evaluated as enum", () => {
+        const result = Validator.validate(schema, "d");
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq(`should be one of "a" | "b" | "c"`);
       });
     });
 
     context("when ArrayType is passed", () => {
       const schema = Schema.Array(Schema.Number());
 
-      it("should return true if value is evaluated as array", () => {
-        expect(Validator.validate(schema, [1, 2, 3, 4])).to.be.true;
+      it("should return success result if value is evaluated as array", () => {
+        expect(Validator.validate(schema, [1, 2, 3, 4]).success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as array", () => {
-        expect(Validator.validate(schema, ["a", "b", "c", "d"])).to.be.false;
-        expect(Validator.validate(schema, "1234")).to.be.false;
+      it("should return failed result if value isn't evaluated as array", () => {
+        const result = Validator.validate(schema, ["1", "2", "3", 4, 5]);
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be Array<number>");
       });
     });
 
     context("when UnionType is passed", () => {
       const schema = Schema.Union([Schema.Number(), Schema.String()]);
 
-      it("should return true if value is evaluated as union", () => {
-        expect(Validator.validate(schema, 1234)).to.be.true;
-        expect(Validator.validate(schema, "1234")).to.be.true;
+      it("should return success result if value is evaluated as union", () => {
+        expect(Validator.validate(schema, 1234).success).to.be.true;
+        expect(Validator.validate(schema, "1234").success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as union", () => {
-        expect(Validator.validate(schema, [])).to.be.false;
-        expect(Validator.validate(schema, {})).to.be.false;
+      it("should return failed result if value isn't evaluated as union", () => {
+        const result = Validator.validate(schema, true);
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be number | string");
       });
     });
 
     context("when ObjectType is passed", () => {
       const schema = Schema.Object({ number: Schema.Number(), optional: Schema.Optional(Schema.String()) });
 
-      it("should return true if value is evaluated as union", () => {
-        expect(Validator.validate(schema, { number: 1234 })).to.be.true;
-        expect(Validator.validate(schema, { number: 1234, optional: "1234" })).to.be.true;
+      it("should return success result if value is evaluated as union", () => {
+        expect(Validator.validate(schema, { number: 1234 }).success).to.be.true;
+        expect(Validator.validate(schema, { number: 1234, optional: "1234" }).success).to.be.true;
       });
 
-      it("should return false if value isn't evaluated as union", () => {
-        expect(Validator.validate(schema, {})).to.be.false;
-        expect(Validator.validate(schema, [])).to.be.false;
-        expect(Validator.validate(schema, null)).to.be.false;
-        expect(Validator.validate(schema, { number: "1234" })).to.be.false;
-        expect(Validator.validate(schema, { number: 1234, optional: 1234 })).to.be.false;
+      it("should return failed result if value isn't evaluated as union", () => {
+        expect(Validator.validate(schema, {}).success).to.be.false;
+        expect(Validator.validate(schema, []).success).to.be.false;
+        expect(Validator.validate(schema, null).success).to.be.false;
+        expect(Validator.validate(schema, { number: "1234" }).success).to.be.false;
+        expect(Validator.validate(schema, { number: 1234, optional: 1234 }).success).to.be.false;
+
+        const result = Validator.validate(schema, { optional: true });
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq(
+          "property [number]: should be provided, property [optional]: should be string"
+        );
       });
     });
   });

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,9 +1,9 @@
 import { RequestParameter } from "./parameter";
-import { AllType } from "./schema";
+import { AllSchema } from "./schema";
 
 export type Method = "get" | "post" | "put" | "patch" | "delete";
 export type Parameters = { [key in string]: RequestParameter };
-export type ResponseBody = { [key in string]: AllType };
+export type ResponseBody = { [key in string]: AllSchema };
 
 export type HTTPRequest<M extends Method, P extends Parameters, R extends ResponseBody> = {
   method: M;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { Schema } from "./schema";
+export { Schema, Resolve } from "./schema";
 export { Parameter } from "./parameter";
 export { HTTP } from "./http";
-export { Validator } from "./validator";
+export { Validator, ValidationResult, ValidationError } from "./validator";
 export { OASBuilder } from "./OASBuilder";

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -1,16 +1,16 @@
-import { AllType } from "./schema";
+import { AllSchema } from "./schema";
 
-type QueryParameter<T extends AllType> = {
+type QueryParameter<T extends AllSchema> = {
   type: "query";
   schema: T;
 };
 
-type PathParameter<T extends AllType> = {
+type PathParameter<T extends AllSchema> = {
   type: "path";
   schema: T;
 };
 
-type RequestBody<T extends AllType> = {
+type RequestBody<T extends AllSchema> = {
   type: "body";
   schema: T;
 };
@@ -18,15 +18,15 @@ type RequestBody<T extends AllType> = {
 export type RequestParameter = QueryParameter<any> | PathParameter<any> | RequestBody<any>;
 
 export class Parameter {
-  public static Query<T extends AllType>(schema: T): QueryParameter<T> {
+  public static Query<T extends AllSchema>(schema: T): QueryParameter<T> {
     return { type: "query", schema };
   }
 
-  public static Path<T extends AllType>(schema: T): PathParameter<T> {
+  public static Path<T extends AllSchema>(schema: T): PathParameter<T> {
     return { type: "path", schema };
   }
 
-  public static Body<T extends AllType>(schema: T): RequestBody<T> {
+  public static Body<T extends AllSchema>(schema: T): RequestBody<T> {
     return { type: "body", schema };
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,34 +6,40 @@ export type TypeOptions = {
 export type NumberType = {
   type: "number";
   options: TypeOptions;
+  definition: string;
 };
 
 export type BooleanType = {
   type: "boolean";
   options: TypeOptions;
+  definition: string;
 };
 
 export type StringType = {
   type: "string";
   options: TypeOptions;
+  definition: string;
 };
 
 export type EnumType = {
   type: "enum";
   values: string[];
   options: TypeOptions;
+  definition: string;
 };
 
 export type ArrayType<T extends AllType> = {
   type: "array";
   itemType: T;
   options: TypeOptions;
+  definition: string;
 };
 
 export type UnionType<T extends AllType> = {
   type: "union";
   itemTypes: T[];
   options: TypeOptions;
+  definition: string;
 };
 
 export type ObjectProperties = { [key in string]: AllType };
@@ -42,6 +48,7 @@ export type ObjectType<T extends ObjectProperties> = {
   type: "object";
   properties: T;
   options: TypeOptions;
+  definition: string;
 };
 
 export type OptionalType<T extends AllType> = Omit<T, "options"> & { options: T["options"] & { optional: true } };
@@ -59,27 +66,47 @@ export type AllType =
 
 export class Schema {
   public static Number(): NumberType {
-    return { type: "number", options: {} };
+    return { type: "number", options: {}, definition: "number" };
   }
 
   public static Boolean(): BooleanType {
-    return { type: "boolean", options: {} };
+    return { type: "boolean", options: {}, definition: "boolean" };
   }
 
   public static String(): StringType {
-    return { type: "string", options: {} };
+    return { type: "string", options: {}, definition: "string" };
   }
 
   public static Enum(values: string[]): EnumType {
-    return { type: "enum", values, options: {} };
+    return { type: "enum", values, options: {}, definition: values.map((value) => `"${value}"`).join(" | ") };
   }
 
   public static Array<T extends AllType>(itemType: T): ArrayType<T> {
-    return { type: "array", itemType, options: {} };
+    return { type: "array", itemType, options: {}, definition: `Array<${itemType.definition}>` };
   }
 
   public static Object<T extends ObjectProperties>(properties: T): ObjectType<T> {
-    return { type: "object", properties, options: {} };
+    const pairs = Object.keys(properties).map((key) => {
+      return [key, properties[key]] as const;
+    });
+    return {
+      type: "object",
+      properties,
+      options: {},
+      definition:
+        pairs.length > 0
+          ? `{\n${pairs
+              .map(
+                (pair) =>
+                  `  ${
+                    pair[1].options.optional
+                      ? `${pair[0]}?: ${pair[1].definition}`
+                      : `${pair[0]}: ${pair[1].definition}`
+                  }`
+              )
+              .join(",\n")}\n}`
+          : "{}",
+    };
   }
 
   public static Optional<T extends AllType>(type: T): OptionalType<T> {
@@ -89,10 +116,16 @@ export class Schema {
 
   public static Nullable<T extends AllType>(type: T): NullableType<T> {
     type.options.nullable = true;
+    type.definition = `${type.definition} | null`;
     return type as NullableType<T>;
   }
 
   public static Union<T extends AllType>(types: T[]): UnionType<T> {
-    return { type: "union", itemTypes: types, options: {} };
+    return {
+      type: "union",
+      itemTypes: types,
+      options: {},
+      definition: types.map((type) => type.definition).join(" | "),
+    };
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -97,16 +97,11 @@ export class Schema {
       options: {},
       definition:
         pairs.length > 0
-          ? `{\n${pairs
-              .map(
-                (pair) =>
-                  `  ${
-                    pair[1].options.optional
-                      ? `${pair[0]}?: ${pair[1].definition}`
-                      : `${pair[0]}: ${pair[1].definition}`
-                  }`
+          ? `{ ${pairs
+              .map((pair) =>
+                pair[1].options.optional ? `${pair[0]}?: ${pair[1].definition}` : `${pair[0]}: ${pair[1].definition}`
               )
-              .join(",\n")}\n}`
+              .join(", ")} }`
           : "{}",
     };
   }
@@ -132,7 +127,9 @@ export class Schema {
           return type;
         })
         .flat() as TypeWithoutUnion<T>[];
-      return Array.from(new Map(flattend.map((type) => [JSON.stringify(type.definition), type]))).map(([, type]) => type);
+      return Array.from(new Map(flattend.map((type) => [JSON.stringify(type.definition), type]))).map(
+        ([, type]) => type
+      );
     })();
 
     return {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,44 +1,83 @@
 import { AllType } from "./schema";
 
+export class ValidationError {
+  constructor(public readonly description: string) {}
+}
+
+interface SuccessResult {
+  success: true;
+}
+
+interface FailedResult {
+  success: false;
+  error: ValidationError;
+}
+
+export type ValidationResult = SuccessResult | FailedResult;
+
 export class Validator {
-  public static validate(schema: AllType, value: any): boolean {
+  public static validate(schema: AllType, value: any): ValidationResult {
     if (value === undefined) {
-      return !!schema.options.optional;
+      return !!schema.options.optional ? this.makeResult(true) : this.makeResult(false, "should be provided");
     }
 
     switch (schema.type) {
       case "number": {
-        return typeof value === "number";
+        return typeof value === "number"
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "string": {
-        return typeof value === "string";
+        return typeof value === "string"
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "boolean": {
-        return typeof value === "boolean";
+        return typeof value === "boolean"
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "enum": {
-        return schema.values.some((v) => v === value);
+        return schema.values.some((v) => v === value)
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be one of ${schema.definition}`);
       }
       case "array": {
         const isArray = value instanceof Array;
         if (!isArray) {
-          return false;
+          return this.makeResult(false, "should be array");
         }
-        return value.every((item) => this.validate(schema.itemType, item));
+        return value.every((item) => this.validate(schema.itemType, item).success)
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "union": {
-        return schema.itemTypes.some((item) => this.validate(item, value));
+        return schema.itemTypes.some((item) => this.validate(item, value).success)
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "object": {
         const isObject = typeof value === "object" && value !== null && !(value instanceof Array);
         if (!isObject) {
-          return false;
+          return this.makeResult(false, "should be object");
         }
-        const keys = Object.keys(schema.properties);
-        return keys.every((key) => {
-          return this.validate(schema.properties[key], value[key]);
-        });
+
+        const failedResults = Object.keys(schema.properties)
+          .map((key) => [key, this.validate(schema.properties[key], value[key])] as const)
+          .filter((result) => !result[1].success) as (readonly [string, FailedResult])[];
+        return failedResults.length === 0
+          ? this.makeResult(true)
+          : this.makeResult(
+              false,
+              failedResults.map((pair) => `property [${pair[0]}]: ${pair[1].error.description}`).join(", ")
+            );
       }
     }
+  }
+
+  private static makeResult(success: true): ValidationResult;
+  private static makeResult(success: false, description: string): ValidationResult;
+  private static makeResult(success: boolean, description?: string): ValidationResult {
+    return success ? { success: true } : { success: false, error: new ValidationError(description!) };
   }
 }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,4 +1,4 @@
-import { AllType } from "./schema";
+import { AllSchema } from "./schema";
 
 export class ValidationError {
   constructor(public readonly description: string) {}
@@ -16,7 +16,7 @@ interface FailedResult {
 export type ValidationResult = SuccessResult | FailedResult;
 
 export class Validator {
-  public static validate(schema: AllType, value: any): ValidationResult {
+  public static validate(schema: AllSchema, value: any): ValidationResult {
     if (value === undefined) {
       return !!schema.options.optional ? this.makeResult(true) : this.makeResult(false, "should be provided");
     }
@@ -47,12 +47,12 @@ export class Validator {
         if (!isArray) {
           return this.makeResult(false, "should be array");
         }
-        return value.every((item) => this.validate(schema.itemType, item).success)
+        return value.every((item) => this.validate(schema.itemSchema, item).success)
           ? this.makeResult(true)
           : this.makeResult(false, `should be ${schema.definition}`);
       }
       case "union": {
-        return schema.itemTypes.some((item) => this.validate(item, value).success)
+        return schema.itemSchemas.some((item) => this.validate(item, value).success)
           ? this.makeResult(true)
           : this.makeResult(false, `should be ${schema.definition}`);
       }


### PR DESCRIPTION
- add definition to Schema objects
```typescript
const numberSchema = Schema.Number();
console.log(numberSchema.definition); // "number"

const objectSchema = Schema.Object({
  a: Schema.Number();
  b: Schema.String();
});
console.log(objectSchema.definition); // "{ a: number, b: string }"
```

- add static type resolution
```typescript
const union  = Schema.Union([Schema.Number(), Schema.String()]);

// number | string
type Union = Resolve<typeof union>;

const user = Schema.Object({
  id: Schema.String(),
  name: Schema.String(),
  email: Schema.Optional(Schema.String()),
  gender: Schema.Nullable(Schema.Enum(["women", "men"])),
  createdAt: Schema.Number(),
});

/*
{
  id: string;
  name: string;
  email?: string | undefined;
  gender: "women" | "men" | null;
  createdAt: number;
}
*/
type User = Resolve<typeof user>;
```

- fix validator result - returns ValidationResult object
```typescript
class ValidationError {
  constructor(public readonly description: string) {}
}

interface SuccessResult {
  success: true;
}

interface FailedResult {
  success: false;
  error: ValidationError;
}

type ValidationResult = SuccessResult | FailedResult;
```

- uniquify duplicated UnionSchema items
```typescript
const union = Schema.Union([
  Schema.Number(),
  Schema.String(),
  Schema.String(),
  Schema.Union([
    Schema.Number(),
    Schema.String(),
    Schema.Boolean(),
  ]),
]);

// (NumberSchema | StringSchema | BooleanSchema)[]
type ItemsType = typeof union.itemSchemas 

console.log(union.definition); // "number | string | boolean"

// number | string | boolean
type Union = Resolve<typeof union>;
```