### PR TITLE
V1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "request-typer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-typer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Make typed request schema and build OpenAPI Specification",
   "files": [
     "dst"

--- a/src/OASBuilder.ts
+++ b/src/OASBuilder.ts
@@ -150,6 +150,9 @@ export class OASBuilder {
       case "enum": {
         return { type: "string", enum: schema.values, ...(nullable ? { nullable } : {}) };
       }
+      case "dict": {
+        return { type: "object", additionalProperties: this.createSchema(schema.valueSchema) };
+      }
     }
   }
 

--- a/src/__test__/OASBuilder.test.ts
+++ b/src/__test__/OASBuilder.test.ts
@@ -11,6 +11,7 @@ describe("OASBuilder", () => {
           name: Schema.String(),
           gender: Schema.Nullable(Schema.Enum(["men", "women"])),
           email: Schema.Optional(Schema.String()),
+          fields: Schema.Dict(Schema.String()),
         },
       };
 
@@ -158,8 +159,9 @@ describe("OASBuilder", () => {
                 name: { type: "string" },
                 gender: { type: "string", enum: ["men", "women"], nullable: true },
                 email: { type: "string" },
+                fields: { type: "object", additionalProperties: { type: "string" } },
               },
-              required: ["id", "name", "gender"],
+              required: ["id", "name", "gender", "fields"],
             },
           },
         },

--- a/src/__test__/schema.test.ts
+++ b/src/__test__/schema.test.ts
@@ -118,6 +118,15 @@ describe("Schema", () => {
     });
   });
 
+  describe("Schema.Dict", () => {
+    it("should return DictSchema object", () => {
+      const schema = Schema.Dict(Schema.String());
+      expect(schema.type).to.be.eq("dict");
+      expect(schema.valueSchema.type).to.be.eq("string");
+      expect(schema.definition).to.be.eq("{ [key: string]: string }");
+    });
+  });
+
   describe("Schema.Optional", () => {
     it("should set Schema.optional option to true", () => {
       const schema = Schema.Optional(Schema.Number());

--- a/src/__test__/validator.test.ts
+++ b/src/__test__/validator.test.ts
@@ -5,7 +5,7 @@ import { Schema } from "../schema";
 
 describe("Validator", () => {
   describe("Validator.validate", () => {
-    context("when NumberType is passed", () => {
+    context("when NumberSchema is passed", () => {
       const schema = Schema.Number();
 
       it("should return success result if value is evaluated as number", () => {
@@ -19,7 +19,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when StringType is passed", () => {
+    context("when StringSchema is passed", () => {
       const schema = Schema.String();
 
       it("should return success result if value is evaluated as string", () => {
@@ -33,7 +33,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when BooleanType is passed", () => {
+    context("when BooleanSchema is passed", () => {
       const schema = Schema.Boolean();
 
       it("should return success result if value is evaluated as boolean", () => {
@@ -48,7 +48,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when EnumType is passed", () => {
+    context("when EnumSchema is passed", () => {
       const schema = Schema.Enum(["a", "b", "c"]);
 
       it("should return success result if value is evaluated as enum", () => {
@@ -64,7 +64,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when ArrayType is passed", () => {
+    context("when ArraySchema is passed", () => {
       const schema = Schema.Array(Schema.Number());
 
       it("should return success result if value is evaluated as array", () => {
@@ -78,7 +78,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when UnionType is passed", () => {
+    context("when UnionSchema is passed", () => {
       const schema = Schema.Union([Schema.Number(), Schema.String()]);
 
       it("should return success result if value is evaluated as union", () => {
@@ -93,7 +93,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when ObjectType is passed", () => {
+    context("when ObjectSchema is passed", () => {
       const schema = Schema.Object({ number: Schema.Number(), optional: Schema.Optional(Schema.String()) });
 
       it("should return success result if value is evaluated as union", () => {
@@ -116,7 +116,7 @@ describe("Validator", () => {
       });
     });
 
-    context("when DictType is passed", () => {
+    context("when DictSchema is passed", () => {
       const schema = Schema.Dict(Schema.String());
 
       it("should return success result if value is evaluated as dict", () => {

--- a/src/__test__/validator.test.ts
+++ b/src/__test__/validator.test.ts
@@ -115,5 +115,20 @@ describe("Validator", () => {
         );
       });
     });
+
+    context("when DictType is passed", () => {
+      const schema = Schema.Dict(Schema.String());
+
+      it("should return success result if value is evaluated as dict", () => {
+        expect(Validator.validate(schema, { a: "1234", b: "1234" }).success).to.be.true;
+        expect(Validator.validate(schema, {}).success).to.be.true;
+      });
+
+      it("should return failed result if value isn't evaluated as dict", () => {
+        const result = Validator.validate(schema, { a: 1234, b: "1234" });
+        expect(result.success).to.be.false;
+        expect(result.success === false && result.error.description).to.be.eq("should be { [key: string]: string }");
+      });
+    });
   });
 });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -53,6 +53,13 @@ export type ObjectSchema<T extends ObjectProperties> = {
   definition: string;
 };
 
+export type DictSchema<T extends AllSchema> = {
+  type: "dict";
+  valueSchema: T;
+  options: SchemaOptions;
+  definition: string;
+};
+
 export type OptionalSchema<T extends AllSchema> = Omit<T, "options"> & { options: T["options"] & { optional: true } };
 
 export type NullableSchema<T extends AllSchema> = Omit<T, "options"> & { options: T["options"] & { nullable: true } };
@@ -64,7 +71,8 @@ export type AllSchema =
   | EnumSchema<any>
   | ArraySchema<any>
   | ObjectSchema<any>
-  | UnionSchema<any>;
+  | UnionSchema<any>
+  | DictSchema<any>;
 
 export type Resolve<T extends AllSchema> = WithOptions<
   T extends { type: "number" }
@@ -172,5 +180,9 @@ export class Schema {
       options: {},
       definition: uniquified.map((schema) => schema.definition).join(" | "),
     };
+  }
+
+  public static Dict<T extends AllSchema>(valueSchema: T): DictSchema<T> {
+    return { type: "dict", valueSchema, options: {}, definition: `{ [key: string]: ${valueSchema.definition} }` };
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -87,6 +87,8 @@ export type Resolve<T extends AllSchema> = WithOptions<
     ? Resolve<T["itemSchema"]>
     : T extends { type: "object" }
     ? UndefinedPropertyToOptional<{ [key in keyof T["properties"]]: Resolve<T["properties"][key]> }>
+    : T extends { type: "dict" }
+    ? { [key: string]: Resolve<T["valueSchema"]> }
     : T extends { type: "union" }
     ? Resolve<T["itemSchemas"][number]>
     : never,

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -72,6 +72,16 @@ export class Validator {
               failedResults.map((pair) => `property [${pair[0]}]: ${pair[1].error.description}`).join(", ")
             );
       }
+      case "dict": {
+        const isObject = typeof value === "object" && value !== null && !(value instanceof Array);
+        if (!isObject) {
+          return this.makeResult(false, "should be object");
+        }
+
+        return Object.keys(value).every((key) => this.validate(schema.valueSchema, value[key]).success)
+          ? this.makeResult(true)
+          : this.makeResult(false, `should be ${schema.definition}`);
+      }
     }
   }
 


### PR DESCRIPTION
- add DictSchema
```typescript
const dict = Schema.Dict(Schema.String());

console.log(dict.definition); // "{ [key: string]: string }"

// { [key: string]: string }
type Dict = Resolve<typeof dict>;
```